### PR TITLE
Empêcher validation si relations incorrectes

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -93,12 +93,12 @@
 <div class="main-content">
     {% for msg in app.session.flashBag.get('success') %}
         <div class="alert alert-success">
-            {{ msg }}
+            {{ msg|raw }}
         </div>
     {% endfor %}
     {% for msg in app.session.flashBag.get('warning') %}
         <div class="alert alert-warning">
-            {{ msg }}
+            {{ msg|raw }}
         </div>
     {% endfor %}
     {% block body %}{% endblock %}

--- a/src/AppBundle/Controller/ClassAssociationController.php
+++ b/src/AppBundle/Controller/ClassAssociationController.php
@@ -216,6 +216,18 @@ class ClassAssociationController extends Controller
         //Denied access if not an authorized validator
         $this->denyAccessUnlessGranted('validate', $classAssociation->getChildClass()->getClassVersionForDisplay());
 
+        //Verifier que les références sont cohérents
+        $nsRefsClassAssociation = $classAssociation->getNamespaceForVersion()->getAllReferencedNamespaces();
+        $nsParent = $classAssociation->getParentClassNamespace();
+        $nsChild = $classAssociation->getChildClassNamespace();
+        if(!$nsRefsClassAssociation->contains($nsParent) || !$nsRefsClassAssociation->contains($nsChild)){
+            $uriNamespaceMismatches = $this->generateUrl('namespace_show', ['id' => $classAssociation->getNamespaceForVersion()->getId(), '_fragment' => 'mismatches']);
+            $this->addFlash('warning', 'This relation can\'t be validated. Check <a href="'.$uriNamespaceMismatches.'">mismatches</a>.');
+            return $this->redirectToRoute('class_association_show', [
+                'id' => $classAssociation->getId()
+            ]);
+        }
+
 
         $classAssociation->setModifier($this->getUser());
 

--- a/src/AppBundle/Controller/EntityAssociationController.php
+++ b/src/AppBundle/Controller/EntityAssociationController.php
@@ -345,6 +345,18 @@ class EntityAssociationController extends Controller
         }
         else throw new AccessDeniedHttpException();
 
+        //Verifier que les références sont cohérents
+        $nsRefsEntityAssociation = $entityAssociation->getNamespaceForVersion()->getAllReferencedNamespaces();
+        $nsSource = $entityAssociation->getParentClassNamespace();
+        $nsTarget = $entityAssociation->getChildClassNamespace();
+        if(!$nsRefsEntityAssociation->contains($nsSource) || !$nsRefsEntityAssociation->contains($nsTarget)){
+            $uriNamespaceMismatches = $this->generateUrl('namespace_show', ['id' => $entityAssociation->getNamespaceForVersion()->getId(), '_fragment' => 'mismatches']);
+            $this->addFlash('warning', 'This relation can\'t be validated. Check <a href="'.$uriNamespaceMismatches.'">mismatches</a>.');
+            return $this->redirectToRoute('entity_association_show', [
+                'id' => $entityAssociation->getId()
+            ]);
+        }
+
         $entityAssociation->setModifier($this->getUser());
 
         $newValidationStatus = new SystemType();

--- a/src/AppBundle/Controller/PropertyAssociationController.php
+++ b/src/AppBundle/Controller/PropertyAssociationController.php
@@ -275,6 +275,17 @@ class PropertyAssociationController extends Controller
         //Denied access if not an authorized validator
         $this->denyAccessUnlessGranted('validate', $propertyAssociation->getChildProperty()->getPropertyVersionForDisplay());
 
+        //Verifier que les références sont cohérents
+        $nsRefsPropertyAssociation = $propertyAssociation->getNamespaceForVersion()->getAllReferencedNamespaces();
+        $nsParent = $propertyAssociation->getParentPropertyNamespace();
+        $nsChild = $propertyAssociation->getChildPropertyNamespace();
+        if(!$nsRefsPropertyAssociation->contains($nsParent) || !$nsRefsPropertyAssociation->contains($nsChild)){
+            $uriNamespaceMismatches = $this->generateUrl('namespace_show', ['id' => $propertyAssociation->getNamespaceForVersion()->getId(), '_fragment' => 'mismatches']);
+            $this->addFlash('warning', 'This relation can\'t be validated. Check <a href="'.$uriNamespaceMismatches.'">mismatches</a>.');
+            return $this->redirectToRoute('class_association_show', [
+                'id' => $propertyAssociation->getId()
+            ]);
+        }
 
         $propertyAssociation->setModifier($this->getUser());
 

--- a/src/AppBundle/Controller/PropertyController.php
+++ b/src/AppBundle/Controller/PropertyController.php
@@ -538,7 +538,8 @@ class PropertyController extends Controller
         $nsRange = $propertyVersion->getRangeNamespace();
         if(!$nsRefsProperty->contains($nsDomain) || !$nsRefsProperty->contains($nsRange)){
             $uriNamespaceMismatches = $this->generateUrl('namespace_show', ['id' => $propertyVersion->getNamespaceForVersion()->getId(), '_fragment' => 'mismatches']);
-            $this->addFlash('warning', 'This property can\'t be validated. Check <a href="'.$uriNamespaceMismatches.'">mismatches</a>.');            return $this->redirectToRoute('property_show', [
+            $this->addFlash('warning', 'This property can\'t be validated. Check <a href="'.$uriNamespaceMismatches.'">mismatches</a>.');
+            return $this->redirectToRoute('property_show', [
                 'id' => $propertyVersion->getProperty()->getId()
             ]);
         }

--- a/src/AppBundle/Controller/PropertyController.php
+++ b/src/AppBundle/Controller/PropertyController.php
@@ -532,6 +532,16 @@ class PropertyController extends Controller
         //Denied access if not an authorized validator
         $this->denyAccessUnlessGranted('validate', $propertyVersion);
 
+        //Verifier que les références sont cohérents
+        $nsRefsProperty = $propertyVersion->getNamespaceForVersion()->getAllReferencedNamespaces();
+        $nsDomain = $propertyVersion->getDomainNamespace();
+        $nsRange = $propertyVersion->getRangeNamespace();
+        if(!$nsRefsProperty->contains($nsDomain) || !$nsRefsProperty->contains($nsRange)){
+            $uriNamespaceMismatches = $this->generateUrl('namespace_show', ['id' => $propertyVersion->getNamespaceForVersion()->getId(), '_fragment' => 'mismatches']);
+            $this->addFlash('warning', 'This property can\'t be validated. Check <a href="'.$uriNamespaceMismatches.'">mismatches</a>.');            return $this->redirectToRoute('property_show', [
+                'id' => $propertyVersion->getProperty()->getId()
+            ]);
+        }
 
         $propertyVersion->setModifier($this->getUser());
 


### PR DESCRIPTION
Il n'est plus possible de valider des relations dont les namespaces des entités Source/Parent/Target/Child ne sont pas référencés dans le namespace de la relation

Resolves #121 