### PR TITLE
Correction d'un bug qui empêchait l'ajout d'un label à une classe ou propriété ongoing

### DIFF
--- a/src/AppBundle/Controller/LabelController.php
+++ b/src/AppBundle/Controller/LabelController.php
@@ -167,36 +167,28 @@ class LabelController  extends Controller
         $canInverseLabel = false;
 
         if($object === 'class') {
-            $class = $em->getRepository('AppBundle:OntoClass')->find($objectId);
-            // Chercher la version ongoing de la classe
-            foreach ($class->getClassVersions() as $cv) {
-                if ($cv->getNamespaceForVersion()->getIsOngoing()) {
-                    $associatedEntity = $cv;
-                    break;
-                }
-            }
+            // Récupérer la version ongoing de la classe identifiée par objectId
+            $associatedEntity = $em->getRepository('AppBundle:OntoClassVersion')->findOngoingVersion($objectId);
+
             if (!$associatedEntity) {
                 throw $this->createNotFoundException('The ongoing version of class n° '.$objectId.' does not exist');
             }
-            $label->setClass($class);
+
+            $label->setClass($associatedEntity->getClass());
             $label->setNamespaceForVersion($associatedEntity->getNamespaceForVersion());
             $associatedObject = $associatedEntity;
             $redirectToRoute = 'class_edit';
             $redirectToRouteFragment = 'identification';
         }
         else if($object === 'property') {
-            $property = $em->getRepository('AppBundle:Property')->find($objectId);
-            // Chercher la version ongoing de la propriété
-            foreach ($property->getPropertyVersions() as $pv) {
-                if ($pv->getNamespaceForVersion()->getIsOngoing()) {
-                    $associatedEntity = $pv;
-                    break;
-                }
-            }
+            // Récupérer la version ongoing de la propriété identifiée par objectId
+            $associatedEntity = $em->getRepository('AppBundle:PropertyVersion')->findOngoingVersion($objectId);
+
             if (!$associatedEntity) {
                 throw $this->createNotFoundException('The ongoing version of property n° '.$objectId.' does not exist');
             }
-            $label->setProperty($associatedEntity);
+
+            $label->setProperty($associatedEntity->getProperty());
             $label->setNamespaceForVersion($associatedEntity->getNamespaceForVersion());
             $associatedObject = $associatedEntity;
             $redirectToRoute = 'property_edit';

--- a/src/AppBundle/Controller/LabelController.php
+++ b/src/AppBundle/Controller/LabelController.php
@@ -46,6 +46,7 @@ class LabelController  extends Controller
     public function editAction(Label $label, Request $request)
     {
         $canInverseLabel = false;
+        $allEntities = null;
         $em = $this->getDoctrine()->getManager();
 
         if(!is_null($label->getClass())){

--- a/src/AppBundle/Controller/LabelController.php
+++ b/src/AppBundle/Controller/LabelController.php
@@ -166,21 +166,37 @@ class LabelController  extends Controller
         $canInverseLabel = false;
 
         if($object === 'class') {
-            $associatedEntity = $em->getRepository('AppBundle:OntoClass')->find($objectId);
-            if (!$associatedEntity) {
-                throw $this->createNotFoundException('The class n° '.$objectId.' does not exist');
+            $class = $em->getRepository('AppBundle:OntoClass')->find($objectId);
+            // Chercher la version ongoing de la classe
+            foreach ($class->getClassVersions() as $cv) {
+                if ($cv->getNamespaceForVersion()->getIsOngoing()) {
+                    $associatedEntity = $cv;
+                    break;
+                }
             }
-            $label->setClass($associatedEntity);
+            if (!$associatedEntity) {
+                throw $this->createNotFoundException('The ongoing version of class n° '.$objectId.' does not exist');
+            }
+            $label->setClass($class);
+            $label->setNamespaceForVersion($associatedEntity->getNamespaceForVersion());
             $associatedObject = $associatedEntity;
             $redirectToRoute = 'class_edit';
             $redirectToRouteFragment = 'identification';
         }
         else if($object === 'property') {
-            $associatedEntity = $em->getRepository('AppBundle:Property')->find($objectId);
+            $property = $em->getRepository('AppBundle:Property')->find($objectId);
+            // Chercher la version ongoing de la propriété
+            foreach ($property->getPropertyVersions() as $pv) {
+                if ($pv->getNamespaceForVersion()->getIsOngoing()) {
+                    $associatedEntity = $pv;
+                    break;
+                }
+            }
             if (!$associatedEntity) {
-                throw $this->createNotFoundException('The property n° '.$objectId.' does not exist');
+                throw $this->createNotFoundException('The ongoing version of property n° '.$objectId.' does not exist');
             }
             $label->setProperty($associatedEntity);
+            $label->setNamespaceForVersion($associatedEntity->getNamespaceForVersion());
             $associatedObject = $associatedEntity;
             $redirectToRoute = 'property_edit';
             $redirectToRouteFragment = 'identification';

--- a/src/AppBundle/Repository/ClassVersionRepository.php
+++ b/src/AppBundle/Repository/ClassVersionRepository.php
@@ -37,6 +37,27 @@ class ClassVersionRepository extends EntityRepository
         return $em->getRepository('AppBundle:OntoClassVersion')->find($stmt->fetch()['pk_class_version']);
     }
 
+    /**
+     * @param int $classId
+     * @return object|null
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function findOngoingVersion($classId)
+    {
+        $sql = "SELECT pk_class_version 
+                FROM che.class_version cv
+                LEFT JOIN che.namespace ns ON cv.fk_namespace_for_version = ns.pk_namespace
+                WHERE fk_class = ? AND ns.is_ongoing = true
+                LIMIT 1";
+
+        $em = $this->getEntityManager();
+        $conn = $em->getConnection();
+        $stmt = $conn->prepare($sql);
+        $stmt->execute(array($classId));
+
+        return $em->getRepository('AppBundle:OntoClassVersion')->find($stmt->fetch()['pk_class_version']);
+    }
+
     public function findIdAndStandardLabelOfClassesVersionByNamespacesId(array $namespacesId)
     {
         // Construit la chaine ?,? pour les namespacesId dans la requête SQL

--- a/src/AppBundle/Repository/PropertyVersionRepository.php
+++ b/src/AppBundle/Repository/PropertyVersionRepository.php
@@ -14,7 +14,7 @@ use Doctrine\ORM\EntityRepository;
 class PropertyVersionRepository extends EntityRepository
 {
     /**
-     * @param OntoClass $class
+     * @param Property $property
      * @param array $namespacesId
      * @return object|null
      * @throws \Doctrine\DBAL\DBALException
@@ -32,6 +32,27 @@ class PropertyVersionRepository extends EntityRepository
         $conn = $em->getConnection();
         $stmt = $conn->prepare($sql);
         $stmt->execute(array_merge(array($property->getId()), $namespacesId));
+
+        return $em->getRepository('AppBundle:PropertyVersion')->find($stmt->fetch()['pk_property_version']);
+    }
+
+    /**
+     * @param int $propertyId
+     * @return object|null
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function findOngoingVersion($propertyId)
+    {
+        $sql = "SELECT pk_property_version 
+                FROM che.property_version pv
+                LEFT JOIN che.namespace ns ON pv.fk_namespace_for_version = ns.pk_namespace
+                WHERE fk_property = ? AND ns.is_ongoing = true
+                LIMIT 1";
+
+        $em = $this->getEntityManager();
+        $conn = $em->getConnection();
+        $stmt = $conn->prepare($sql);
+        $stmt->execute(array($propertyId));
 
         return $em->getRepository('AppBundle:PropertyVersion')->find($stmt->fetch()['pk_property_version']);
     }


### PR DESCRIPTION
Stephen a remarqué qu'on ne pouvait pas ajouter un nouveau libellé dans une classe pourtant ongoing (tout en gardant l'ancien label pour archivage) = Erreur 403 pas l'autorisation

En effet, l'associatedObject controlé était celui de la classe (au sens général) et non la classVersion.